### PR TITLE
Fix for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 setup(name='visTorch',
       version='0.0.1',
       py_modules=['visTorch'],
+      packages=['visTorch'],
       author='Anurag Koul',
       author_email='koulanurag@gmail.com',
       long_description=open(path.join(path.abspath(path.dirname(__file__)), 'README.md')).read(),


### PR DESCRIPTION
Fixes the problem:
````
Traceback (most recent call last):
  File "mnist_autoencoder.py", line 8, in <module>
    from visTorch import visboard
ModuleNotFoundError: No module named 'visTorch'
````